### PR TITLE
added marker.element check in m.add

### DIFF
--- a/src/mmg.js
+++ b/src/mmg.js
@@ -58,7 +58,7 @@ function mmg() {
     };
 
     m.add = function(marker) {
-        if (!marker) return null;
+        if (!marker || !marker.element) return null;
         parent.appendChild(marker.element);
         markers.push(marker);
         return marker;


### PR DESCRIPTION
covers a bit of an edge case where a valid marker exists, but a marker element is not returned (filtering points inside factory)
