### PR TITLE
Align tooltip bottoms to marker tops. Bump to 0.2.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+### 0.2.4
+
+* Align tooltips' bottoms to their markers' tops. Handles resizable tooltips.
+
 ### 0.2.3
 
 * Removed indexOf shim. no functional change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mmg",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "Simple markers for Modest Maps",
     "repository": {
         "type": "git",

--- a/src/mmg_interaction.js
+++ b/src/mmg_interaction.js
@@ -82,12 +82,14 @@ function mmg_interaction(mmg) {
 
             var tooltip = document.createElement('div');
             tooltip.className = 'wax-movetip';
+            tooltip.style.width = '100%';
 
             var wrapper = tooltip.appendChild(document.createElement('div'));
-            wrapper.style.position = 'absolute';
+            wrapper.style.cssText = 'position: absolute; pointer-events: none;';
 
             var intip = wrapper.appendChild(document.createElement('div'));
             intip.className = 'wax-intip';
+            intip.style.cssText = 'pointer-events: auto;';
 
             if (typeof content == 'string') {
                 intip.innerHTML = content;

--- a/src/mmg_interaction.js
+++ b/src/mmg_interaction.js
@@ -92,13 +92,9 @@ function mmg_interaction(mmg) {
                 intip.appendChild(content);
             }
 
-            // Here we're adding the tooltip to the dom briefly
-            // to gauge its size. There should be a better way to do this.
-            document.body.appendChild(tooltip);
-            intip.style.marginTop = -(
-                (marker.element.offsetHeight * 0.5) +
-                tooltip.offsetHeight + 20) + 'px';
-            document.body.removeChild(tooltip);
+            // Align the bottom of the tooltip with the top of its marker
+            tooltip.style.bottom = marker.element.offsetParent.offsetHeight -
+                                   marker.element.offsetTop + 10 + 'px';
 
             if (show_on_hover) {
                 tooltip.onmouseover = function() {

--- a/src/mmg_interaction.js
+++ b/src/mmg_interaction.js
@@ -83,7 +83,10 @@ function mmg_interaction(mmg) {
             var tooltip = document.createElement('div');
             tooltip.className = 'wax-movetip';
 
-            var intip = tooltip.appendChild(document.createElement('div'));
+            var wrapper = tooltip.appendChild(document.createElement('div'));
+            wrapper.style.position = 'absolute';
+
+            var intip = wrapper.appendChild(document.createElement('div'));
             intip.className = 'wax-intip';
 
             if (typeof content == 'string') {
@@ -93,8 +96,7 @@ function mmg_interaction(mmg) {
             }
 
             // Align the bottom of the tooltip with the top of its marker
-            tooltip.style.bottom = marker.element.offsetParent.offsetHeight -
-                                   marker.element.offsetTop + 10 + 'px';
+            wrapper.style.bottom = marker.element.offsetHeight / 2 + 20 + 'px';
 
             if (show_on_hover) {
                 tooltip.onmouseover = function() {


### PR DESCRIPTION
@tmcw mind taking a look at this? Found an issue where tooltips that resize, like those with images in them are not positioning correctly. Positioning with bottom instead of margin-top should do the trick.

Example: https://tiles.mapbox.com/dhcole/map/map-9ojjpt2o
