### PR TITLE
Use div instead of h1 to prevent conflict with host application style sheets

### DIFF
--- a/src/mmg.css
+++ b/src/mmg.css
@@ -40,10 +40,3 @@
 	left:50%;
 	margin-left:-18px;
     }
-
-h1.mmg-title {
-    font-size:small;
-    margin:0;
-    padding:0;
-    font-weight:normal;
-}

--- a/src/mmg_interaction.js
+++ b/src/mmg_interaction.js
@@ -18,7 +18,7 @@ function mmg_interaction(mmg) {
             props = feature.properties;
 
         if (props.title) {
-            o += '<h1 class="mmg-title">' + props.title + '</h1>';
+            o += '<div class="mmg-title">' + props.title + '</div>';
         }
         if (props.description) {
             o += '<div class="mmg-description">' + props.description + '</div>';


### PR DESCRIPTION
Using `h1` is likely to cause conflict with styles that loosely declare and `h1` style for the whole site. Overriding is hard and would require setting every possible property, like background, padding, margin..., to a reset value. Also, semantically, pages should only have one h1.
