### PR TITLE
Only wrap markers if they would be visible

### DIFF
--- a/src/markers.js
+++ b/src/markers.js
@@ -45,20 +45,26 @@ mapbox.markers.layer = function() {
         // remember the tile coordinate so we don't have to reproject every time
         if (!marker.coord) marker.coord = m.map.locationCoordinate(marker.location);
         var pos = m.map.coordinatePoint(marker.coord);
-        var pos_loc;
+        var pos_loc, new_pos;
 
         // If this point has wound around the world, adjust its position
         // to the new, onscreen location
         if (pos.x < 0) {
             pos_loc = new MM.Location(marker.location.lat, marker.location.lon);
             pos_loc.lon += Math.ceil((left.lon - marker.location.lon) / 360) * 360;
-            pos = m.map.locationPoint(pos_loc);
-            marker.coord = m.map.locationCoordinate(pos_loc);
+            new_pos = m.map.locationPoint(pos_loc);
+            if (new_pos.x < m.map.dimensions.x) {
+                pos = new_pos;
+                marker.coord = m.map.locationCoordinate(pos_loc);
+            }
         } else if (pos.x > m.map.dimensions.x) {
             pos_loc = new MM.Location(marker.location.lat, marker.location.lon);
             pos_loc.lon -= Math.ceil((marker.location.lon - right.lon) / 360) * 360;
-            pos = m.map.locationPoint(pos_loc);
-            marker.coord = m.map.locationCoordinate(pos_loc);
+            new_pos = m.map.locationPoint(pos_loc);
+            if (new_pos.x > 0) {
+                pos = new_pos;
+                marker.coord = m.map.locationCoordinate(pos_loc);
+            }
         }
 
         pos.scale = 1;


### PR DESCRIPTION
Markers located off the map were being switched back and for between both sides, causing flickering near edges as reported in mapbox/mapbox.js#107

This only wraps the marker if it would be visible.

/cc @tmcw 
