### PR TITLE
Allow re-adding feature with the same key 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/markers.js
+++ b/src/markers.js
@@ -115,6 +115,8 @@ mapbox.markers.layer = function() {
         m.parent.removeChild(marker.element);
         for (var i = 0; i < markers.length; i++) {
             if (markers[i] === marker) {
+                var id = keyfn(marker.data);
+                delete index[id];
                 markers.splice(i, 1);
                 return marker;
             }

--- a/test/spec/markers.js
+++ b/test/spec/markers.js
@@ -112,6 +112,19 @@ describe('mapbox.markers', function() {
             layer.features(null);
             expect(layer.parent.childNodes.length).toEqual(0);
         });
+
+        it('should be able to re-add a marker with the same key', function () {
+            var mapdiv = document.createElement('div');
+            var layer = mapbox.markers.layer().features(test_features);
+            layer.key(function () { return 1; });
+            var m = new MM.Map(mapdiv, layer)
+            .setCenterZoom(new MM.Location(37.8, -77), 7);
+            expect(layer.parent.childNodes.length).toEqual(1);
+            layer.features(null);
+            expect(layer.parent.childNodes.length).toEqual(0);
+            layer.features(test_features);
+            expect(layer.parent.childNodes.length).toEqual(1);
+        });
     });
 
     describe('sorting function', function() {


### PR DESCRIPTION
markers.js keeps a cache of markers used for a feature to
not re-create the marker when a feature is repositioned.
That cache is however never cleared when a feature is removed, making
it impossible to re-add the same feature after removing it once.
