### PR TITLE
Only clear the markers cache for markers created by `features()`

### DIFF
--- a/src/markers.js
+++ b/src/markers.js
@@ -115,8 +115,6 @@ mapbox.markers.layer = function() {
         m.parent.removeChild(marker.element);
         for (var i = 0; i < markers.length; i++) {
             if (markers[i] === marker) {
-                var id = keyfn(marker.data);
-                delete index[id];
                 markers.splice(i, 1);
                 return marker;
             }
@@ -167,6 +165,7 @@ mapbox.markers.layer = function() {
                 } else {
                     // marker needs to be added to the map
                     index[id] = m.add({
+                        id: id,
                         element: factory(features[i]),
                         location: new MM.Location(
                             features[i].geometry.coordinates[1],
@@ -180,6 +179,8 @@ mapbox.markers.layer = function() {
 
         for (var k = markers.length - 1; k >= 0; k--) {
             if (markers[k].touch === false) {
+                if (typeof markers[k].id !== 'undefined')
+                    delete index[markers[k].id];
                 m.remove(markers[k]);
             }
         }

--- a/test/spec/markers.js
+++ b/test/spec/markers.js
@@ -115,8 +115,9 @@ describe('mapbox.markers', function() {
 
         it('should be able to re-add a marker with the same key', function () {
             var mapdiv = document.createElement('div');
-            var layer = mapbox.markers.layer().features(test_features);
+            var layer = mapbox.markers.layer();
             layer.key(function () { return 1; });
+            layer.features(test_features);
             var m = new MM.Map(mapdiv, layer)
             .setCenterZoom(new MM.Location(37.8, -77), 7);
             expect(layer.parent.childNodes.length).toEqual(1);

--- a/test/spec/markers_interaction.js
+++ b/test/spec/markers_interaction.js
@@ -55,6 +55,30 @@ describe('mapbox.markers interaction', function() {
         expect(m.markers().length).toEqual(1);
     });
 
+    it('does not mess with `key`ed features', function () {
+        var m = mapbox.markers.layer();
+        var mi = mapbox.markers.interaction(m);
+        // this would throw if it would be called with a tooltips empty `data`
+        m.key(function (f) { return f.properties.title; });
+
+        function check() {
+            m.features([{
+                geometry: { coordinates: [0, 0] },
+                properties: { title: 'Foo' }
+            }]);
+            expect(m.markers().length).toEqual(1);
+            m.markers()[0].showTooltip();
+            expect(m.markers().length).toEqual(2);
+        }
+        check();
+        // TODO: automatically removing the tooltip when a marker is removed
+        // is not yet possible, so clear the tooltips manually
+        mi.hideTooltips();
+        m.features([]);
+        expect(m.markers().length).toEqual(0);
+        check();
+    });
+
     it('multiple interactions will not attach, only the first', function() {
         var m = mapbox.markers.layer();
         var a = mapbox.markers.interaction(m);


### PR DESCRIPTION
This fixes the problem that tooltips are themselves just markers but don’t share
the same `data` and are not added to the marker cache at all.
See https://github.com/mapbox/markers.js/pull/52#issuecomment-14909544
